### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@commitlint/cli": "^17.0.0",
     "@commitlint/config-conventional": "^17.0.0",
     "@commitlint/config-nx-scopes": "^17.6.4",
-    "@google/semantic-release-replace-plugin": "^1.2.0",
+    "semantic-release-replace-plugin": "^1.2.0",
     "@nrwl/eslint-plugin-nx": "16.0.1",
     "@nrwl/jest": "16.0.1",
     "@nrwl/js": "16.0.1",

--- a/packages/runner-commons/project.json
+++ b/packages/runner-commons/project.json
@@ -58,7 +58,7 @@
             ]
           }],
           [
-            "@google/semantic-release-replace-plugin",
+            "semantic-release-replace-plugin",
             {
               "replacements": [
                 {


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).